### PR TITLE
Use RF delay instead of RF dead time

### DIFF
--- a/src/mrseq/scripts/t1_inv_rec_gre_single_line.py
+++ b/src/mrseq/scripts/t1_inv_rec_gre_single_line.py
@@ -155,7 +155,7 @@ def t1_inv_rec_gre_single_line_kernel(
 
             # calculate and add inversion time (TI) delay.
             # TI is defined as time from middle of inversion pulse to middle of excitation pulse.
-            ti_delay = ti - time_since_inversion - system.rf_dead_time - rf_duration / 2
+            ti_delay = ti - time_since_inversion - max(rf.dead_time, rf.delay) - rf_duration / 2
             ti_delay = round_to_raster(ti_delay, system.block_duration_raster)
             if ti_delay < 0:
                 raise ValueError(

--- a/src/mrseq/scripts/t1_inv_rec_gre_single_line.py
+++ b/src/mrseq/scripts/t1_inv_rec_gre_single_line.py
@@ -155,7 +155,7 @@ def t1_inv_rec_gre_single_line_kernel(
 
             # calculate and add inversion time (TI) delay.
             # TI is defined as time from middle of inversion pulse to middle of excitation pulse.
-            ti_delay = ti - time_since_inversion - max(rf.dead_time, rf.delay) - rf_duration / 2
+            ti_delay = ti - time_since_inversion - rf.delay - rf_duration / 2
             ti_delay = round_to_raster(ti_delay, system.block_duration_raster)
             if ti_delay < 0:
                 raise ValueError(

--- a/src/mrseq/scripts/t1_inv_rec_se_single_line.py
+++ b/src/mrseq/scripts/t1_inv_rec_se_single_line.py
@@ -212,7 +212,7 @@ def t1_inv_rec_se_single_line_kernel(
 
             # calculate and add inversion time (TI) delay.
             # TI is defined as time from middle of inversion pulse to middle of excitation pulse.
-            ti_delay = ti - time_since_inversion - max(rf90.dead_time, rf90.delay) - rf90_duration / 2
+            ti_delay = ti - time_since_inversion - rf90.delay - rf90_duration / 2
             ti_delay = round_to_raster(ti_delay, system.block_duration_raster)
             if ti_delay < 0:
                 raise ValueError(

--- a/src/mrseq/scripts/t1_inv_rec_se_single_line.py
+++ b/src/mrseq/scripts/t1_inv_rec_se_single_line.py
@@ -212,7 +212,7 @@ def t1_inv_rec_se_single_line_kernel(
 
             # calculate and add inversion time (TI) delay.
             # TI is defined as time from middle of inversion pulse to middle of excitation pulse.
-            ti_delay = ti - time_since_inversion - system.rf_dead_time - rf90_duration / 2
+            ti_delay = ti - time_since_inversion - max(rf90.dead_time, rf90.delay) - rf90_duration / 2
             ti_delay = round_to_raster(ti_delay, system.block_duration_raster)
             if ti_delay < 0:
                 raise ValueError(


### PR DESCRIPTION
Helge found out that using `system.rf_dead_time` might not be what is actually used in the RF object:

https://github.com/PTB-MR/qmri-low-field/pull/38#issuecomment-2701251207


