### PR TITLE
Limit pytest-cov version to fix reports in PRs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "codecov",
     "pre-commit",
     "pytest",
-    "pytest-cov",
+    "pytest-cov<6.1",
     "pytest-xdist",
 ]
 


### PR DESCRIPTION
similar to what we did here: https://github.com/PTB-MR/mrpro/pull/758